### PR TITLE
changing __docstring__ into __doc__

### DIFF
--- a/SCALE10x/python-decorators.rst
+++ b/SCALE10x/python-decorators.rst
@@ -43,7 +43,7 @@ Functions have attributes
 
     >>> spam.func_name
     'spam'
-    >>> spam.__docstring__
+    >>> spam.__doc__
     "A function"
     
 A function knows about itself
@@ -310,7 +310,7 @@ Warning: Function attributes get mangled in decorators
                 result = function(*args, **kwargs)
                 result = result[:length]
             return wrapper
-            wrapper.__docstring__ = function.__docstring__
+            wrapper.__doc__ = function.__doc__
         return decorator
 
 You can also use functools to deal with this issue, but it's not as clear a read
@@ -325,7 +325,7 @@ You can also use functools to deal with this issue, but it's not as clear a read
                 result = function(*args, **kwargs)
                 result = result[:length]
             return wrapper
-            wrapper.__docstring__ = function.__docstring__
+            wrapper.__doc__ = function.__doc__
         return decorator
 
 Uses for decorators


### PR DESCRIPTION
`__docstring__` is the incorrect magic variable. `__doc__` is the correct one.