### PR TITLE
docs: Fix a few typos

### DIFF
--- a/DjangoCon2011/django-core-dev-panel.rst
+++ b/DjangoCon2011/django-core-dev-panel.rst
@@ -57,7 +57,7 @@ by cast of thousands
  
  * Justin Bronn
  
-    * Linux kernal hacking
+    * Linux kernel hacking
  
  * Karen Tracy
  

--- a/DjangoConEurope2012/django-and-the-real-time-web.rst
+++ b/DjangoConEurope2012/django-and-the-real-time-web.rst
@@ -38,7 +38,7 @@ MVC
 
 How it works on the web:
 
-* Listen for reqursts
+* Listen for requests
 
     * Load session state for this user
     * Persist session state, clean up objects

--- a/KiwiPycon2011/async_event_programming.rst
+++ b/KiwiPycon2011/async_event_programming.rst
@@ -35,7 +35,7 @@ Really awesome until you hit issues like:
 Multiprocessing
 ===============
 
-* Let the kernal care
+* Let the kernel care
 * Easy to write MP code on unix-likes
 * Can even go multi-system
 

--- a/KiwiPycon2011/website_command_line.rst
+++ b/KiwiPycon2011/website_command_line.rst
@@ -21,7 +21,7 @@ see: http://validation.linaro.org/
 Why a command-line interface?
 ==============================
 
-* We want to do things like trigger test runs when a kernal build finished
+* We want to do things like trigger test runs when a kernel build finished
 * This basically means some kind of Remote Procedure Call (RPC)
 
 Need security

--- a/PyConPL2012/forms_in_python.rst
+++ b/PyConPL2012/forms_in_python.rst
@@ -29,7 +29,7 @@ Forms are ubiquitous across all Python frameworks
     * This is where they tend to see our mistakes
     
 * Our first line of defense against security against CSRF and other attack methods.
-* Boilerplate and repition removal
+* Boilerplate and repetition removal
 
 Scope of Features
 -----------------------

--- a/PyconPH2012/ansible.rst
+++ b/PyconPH2012/ansible.rst
@@ -21,7 +21,7 @@ Dependencies
 
 * Jinja2 (in case you want fancy templates of configuration files)
 * PyYAML (for settings configuration)
-* parameiko
+* paramiko
 
 Question
 --------

--- a/django13webinar/whats_new.rst
+++ b/django13webinar/whats_new.rst
@@ -102,7 +102,7 @@ Only on database fields that are defined to accept null::
 
     author = models.ForeignKey(Person, on_delete=models.SET_NULL)
     
-For setting a new value via a handy sentinal object::
+For setting a new value via a handy sentinel object::
 
     def get_dummy_person():
     p, created = Person.objects.get_or_create(name='DELETED')

--- a/socalpiggies/20110526-hettinger.rst
+++ b/socalpiggies/20110526-hettinger.rst
@@ -111,7 +111,7 @@ Fun things to do with Python
 Not so bad
 -----------
 
-The iter() function has a two argument form that takes a sentinal value::
+The iter() function has a two argument form that takes a sentinel value::
 
     for block in iter(partial(f.read,20), "")
         ...


### PR DESCRIPTION
There are small typos in:
- DjangoCon2011/django-core-dev-panel.rst
- DjangoConEurope2012/django-and-the-real-time-web.rst
- KiwiPycon2011/async_event_programming.rst
- KiwiPycon2011/website_command_line.rst
- PyConPL2012/forms_in_python.rst
- PyconPH2012/ansible.rst
- django13webinar/whats_new.rst
- socalpiggies/20110526-hettinger.rst

Fixes:
- Should read `kernel` rather than `kernal`.
- Should read `sentinel` rather than `sentinal`.
- Should read `requests` rather than `reqursts`.
- Should read `repetition` rather than `repition`.
- Should read `paramiko` rather than `parameiko`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md